### PR TITLE
fix: disabled back button for Map Fragment in tablet view

### DIFF
--- a/android/app/src/googleplay/java/org/fossasia/openevent/fragments/MapsFragment.java
+++ b/android/app/src/googleplay/java/org/fossasia/openevent/fragments/MapsFragment.java
@@ -37,6 +37,7 @@ import org.fossasia.openevent.R;
 import org.fossasia.openevent.data.Event;
 import org.fossasia.openevent.data.Microlocation;
 import org.fossasia.openevent.dbutils.RealmDataRepository;
+import org.fossasia.openevent.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,7 +63,9 @@ public class MapsFragment extends Fragment implements LocationListener, OnMapRea
         super.onCreate(savedInstanceState);
 
         toolbar = ((AppCompatActivity) getActivity()).getSupportActionBar();
-        toolbar.setDisplayHomeAsUpEnabled(true);
+        if(!Utils.getTwoPane()) {
+            toolbar.setDisplayHomeAsUpEnabled(true);
+        }
         toolbar.setDisplayShowCustomEnabled(true);
     }
 

--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -176,6 +176,7 @@ public class MainActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         mTwoPane = drawerLayout == null;
+        Utils.setTwoPane(mTwoPane);
 
         disposable = new CompositeDisposable();
 

--- a/android/app/src/main/java/org/fossasia/openevent/utils/Utils.java
+++ b/android/app/src/main/java/org/fossasia/openevent/utils/Utils.java
@@ -7,6 +7,8 @@ import org.fossasia.openevent.api.Urls;
 
 public class Utils {
 
+    private static boolean isTwoPane = false;
+
     public static boolean isEmpty(String string) {
         return string == null || string.trim().length() == 0;
     }
@@ -52,4 +54,11 @@ public class Utils {
         return null;
     }
 
+    public static void setTwoPane(boolean value) {
+        isTwoPane = value;
+    }
+
+    public static boolean getTwoPane() {
+        return isTwoPane;
+    }
 }


### PR DESCRIPTION
Fixes #1720 

Changes: 
Disabled back button for Map Fragment for tablet view of the app.

Screenshots for the change: 
![19264107_10211597374164410_1936271897_o](https://user-images.githubusercontent.com/8268392/27255755-e8be7a5c-53c2-11e7-9059-c1cf4369e532.jpg)
