### PR TITLE
fix: UI bug fix

### DIFF
--- a/android/app/src/main/res/layout/activity_speakers.xml
+++ b/android/app/src/main/res/layout/activity_speakers.xml
@@ -86,6 +86,7 @@
                     android:layout_height="wrap_content"
                     android:textColor="@android:color/white"
                     android:textSize="@dimen/text_size_large"
+                    android:layout_marginRight="@dimen/layout_margin_extra_large"
                     android:layout_marginLeft="@dimen/layout_margin_extra_large"
                     tools:text="Subtitle"
                     android:paddingBottom="@dimen/padding_small"/>


### PR DESCRIPTION
Fixes #1926 

margin-right was increased so the textview no longer overlaps the share button.

Screenshots for the change: 
Before:
![whatsapp image 2017-09-24 at 12 53 29 am](https://user-images.githubusercontent.com/25136650/30777078-cc02c836-a0d0-11e7-87b2-74cfada6bb0c.jpeg)

After:
![whatsapp image 2017-09-24 at 1 40 27 am](https://user-images.githubusercontent.com/25136650/30777085-e7f79d28-a0d0-11e7-8120-f9d77c2eb216.jpeg)

