### PR TITLE
fix : Show copyright menu-item in AboutFragment

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/fragments/AboutFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/AboutFragment.java
@@ -209,6 +209,9 @@ public class AboutFragment extends BaseFragment {
             case R.id.action_ticket_home:
                 Utils.setUpCustomTab(getContext(), event.getTicketUrl());
                 break;
+            case R.id.action_copyright:
+                displayCopyrightInformation();
+                break;
             default:
                 //No option selected. Do Nothing..
         }

--- a/android/app/src/main/res/menu/menu_home.xml
+++ b/android/app/src/main/res/menu/menu_home.xml
@@ -15,4 +15,9 @@
         android:icon="@drawable/ic_ticket_white_24dp"
         android:title="Get Tickets"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_copyright"
+        android:title="@string/copyright"
+        app:showAsAction="never"/>
 </menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="share">Share</string>
     <string name="add_to_calendar">Add to Calendar</string>
     <string name="upcoming">Upcoming</string>
+    <string name="copyright">Copyright</string>
 
     <!--Search Titles-->
     <string name="global_search_hint">Search App</string>


### PR DESCRIPTION
Fixes #1947 

Changes: Adds menu-item for Copyright in `menu_home` inflated in `AboutFragment`

Screenshots for the change: 
<img src="https://user-images.githubusercontent.com/22222147/31559596-cc53956a-b06e-11e7-8897-44190a88768a.png" width=270px height=480px>
