### PR TITLE
Fix #1970 appropriate text displayed when there is no result

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/LocationActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/LocationActivity.java
@@ -61,6 +61,8 @@ public class LocationActivity extends BaseActivity implements SearchView.OnQuery
     RecyclerView sessionRecyclerView;
     @BindView(R.id.txt_no_sessions)
     TextView noSessionsView;
+    @BindView(R.id.txt_no_result_loc_sessions)
+    protected TextView noResultSessionsView;
     @BindView(R.id.toolbar_locations)
     Toolbar toolbar;
 
@@ -186,6 +188,7 @@ public class LocationActivity extends BaseActivity implements SearchView.OnQuery
         }
     }
 
+
     @Override
     protected int getLayoutResource() {
         return R.layout.activity_locations;
@@ -277,6 +280,7 @@ public class LocationActivity extends BaseActivity implements SearchView.OnQuery
     public boolean onQueryTextChange(final String query) {
         searchText = query;
         sessionsListAdapter.filter(searchText);
+        Utils.displayNoResults(noResultSessionsView, sessionRecyclerView, noSessionsView, sessionsListAdapter.getItemCount());
 
         return false;
     }

--- a/android/app/src/main/java/org/fossasia/openevent/activities/TrackSessionsActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/TrackSessionsActivity.java
@@ -82,6 +82,8 @@ public class TrackSessionsActivity extends BaseActivity implements SearchView.On
     RecyclerView sessionsRecyclerView;
     @BindView(R.id.txt_no_sessions)
     TextView noSessionsView;
+    @BindView(R.id.txt_no_result_sessions)
+    protected TextView noResultSessionsView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -178,6 +180,7 @@ public class TrackSessionsActivity extends BaseActivity implements SearchView.On
             sessionsRecyclerView.setVisibility(View.GONE);
         }
     }
+
 
     private void setUiColor(int color) {
         toolbar.setBackgroundColor(color);
@@ -300,6 +303,7 @@ public class TrackSessionsActivity extends BaseActivity implements SearchView.On
     public boolean onQueryTextChange(String query) {
         searchText = query;
         sessionsListAdapter.filter(searchText);
+        Utils.displayNoResults(noResultSessionsView, sessionsRecyclerView, noSessionsView, sessionsListAdapter.getItemCount());
 
         return true;
     }

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/DayScheduleFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/DayScheduleFragment.java
@@ -55,6 +55,7 @@ public class DayScheduleFragment extends BaseFragment implements SearchView.OnQu
     @BindView(R.id.schedule_swipe_refresh) SwipeRefreshLayout swipeRefreshLayout;
     @BindView(R.id.list_schedule) RecyclerView dayRecyclerView;
     @BindView(R.id.txt_no_schedule) TextView noSchedule;
+    @BindView(R.id.txt_no_result_schedule) protected TextView noResultsSchedule;
 
     private List<Session> sessions = new ArrayList<>();
     private List<Session> filteredSessions = new ArrayList<>();
@@ -162,6 +163,7 @@ public class DayScheduleFragment extends BaseFragment implements SearchView.OnQu
         }
     }
 
+
     @Override
     protected int getLayoutResource() {
         return R.layout.list_schedule;
@@ -223,6 +225,8 @@ public class DayScheduleFragment extends BaseFragment implements SearchView.OnQu
         searchText = query;
 
         dayScheduleAdapter.filter(searchText);
+        Utils.displayNoResults(noResultsSchedule, dayRecyclerView, noSchedule, dayScheduleAdapter.getItemCount());
+
         return true;
     }
 

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/LocationsFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/LocationsFragment.java
@@ -48,13 +48,19 @@ public class LocationsFragment extends BaseFragment implements SearchView.OnQuer
 
     final private String SEARCH = "searchText";
 
-    @BindView(R.id.locations_swipe_refresh) SwipeRefreshLayout swipeRefreshLayout;
-    @BindView(R.id.list_locations) RecyclerView locationsRecyclerView;
-    @BindView(R.id.txt_no_microlocations) TextView noMicrolocationsView;
+    @BindView(R.id.locations_swipe_refresh)
+    SwipeRefreshLayout swipeRefreshLayout;
+    @BindView(R.id.list_locations)
+    protected RecyclerView locationsRecyclerView;
+    @BindView(R.id.txt_no_microlocations)
+    protected TextView noMicrolocationsView;
+    @BindView(R.id.txt_no_result_locations)
+    protected TextView noResultsView;
+
 
     private List<Microlocation> locations = new ArrayList<>();
     private LocationsListAdapter locationsListAdapter;
-    
+
     private String searchText = "";
     private SearchView searchView;
 
@@ -165,6 +171,8 @@ public class LocationsFragment extends BaseFragment implements SearchView.OnQuer
         locationsListAdapter.filter(query);
 
         searchText = query;
+        Utils.displayNoResults(noResultsView, locationsRecyclerView, noMicrolocationsView, locationsListAdapter.getItemCount());
+
         return true;
     }
 
@@ -181,8 +189,8 @@ public class LocationsFragment extends BaseFragment implements SearchView.OnQuer
 
         // Remove listeners to fix memory leak
         realmResults.removeAllChangeListeners();
-        if(swipeRefreshLayout != null) swipeRefreshLayout.setOnRefreshListener(null);
-        if(searchView != null) searchView.setOnQueryTextListener(null);
+        if (swipeRefreshLayout != null) swipeRefreshLayout.setOnRefreshListener(null);
+        if (searchView != null) searchView.setOnQueryTextListener(null);
     }
 
     @Subscribe

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
@@ -55,6 +55,8 @@ public class SpeakersListFragment extends BaseFragment implements SearchView.OnQ
 
     @BindView(R.id.speaker_swipe_refresh) SwipeRefreshLayout swipeRefreshLayout;
     @BindView(R.id.txt_no_speakers)  TextView noSpeakersView;
+    @BindView(R.id.txt_no_result_speakers)  protected TextView noSpeakersResultView;
+
     @BindView(R.id.rv_speakers) RecyclerView speakersRecyclerView;
 
     private List<Speaker> speakers = new ArrayList<>();
@@ -126,7 +128,7 @@ public class SpeakersListFragment extends BaseFragment implements SearchView.OnQ
         if (!speakers.isEmpty()) {
             noSpeakersView.setVisibility(View.GONE);
             speakersRecyclerView.setVisibility(View.VISIBLE);
-        } else {
+        } else if(noSpeakersResultView.getVisibility() != View.VISIBLE){
             noSpeakersView.setVisibility(View.VISIBLE);
             speakersRecyclerView.setVisibility(View.GONE);
         }
@@ -256,6 +258,7 @@ public class SpeakersListFragment extends BaseFragment implements SearchView.OnQ
     public boolean onQueryTextChange(String query) {
         searchText = query;
         speakersListAdapter.filter(query);
+        Utils.displayNoResults(noSpeakersResultView, speakersRecyclerView, noSpeakersView, speakersListAdapter.getItemCount());
 
         return true;
     }

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/TracksFragment.java
@@ -53,6 +53,7 @@ public class TracksFragment extends BaseFragment implements SearchView.OnQueryTe
 
     @BindView(R.id.tracks_swipe_refresh) SwipeRefreshLayout swipeRefreshLayout;
     @BindView(R.id.txt_no_tracks) TextView noTracksView;
+    @BindView(R.id.txt_no_result_tracks) protected TextView noResultsTracksView;
     @BindView(R.id.list_tracks) RecyclerView tracksRecyclerView;
     @BindView(R.id.tracks_frame) View windowFrame;
 
@@ -120,6 +121,7 @@ public class TracksFragment extends BaseFragment implements SearchView.OnQueryTe
         }
     }
 
+
     @Override
     protected int getLayoutResource() {
         return R.layout.list_tracks;
@@ -166,6 +168,7 @@ public class TracksFragment extends BaseFragment implements SearchView.OnQueryTe
     public boolean onQueryTextChange(String query) {
         searchText = query;
         tracksListAdapter.filter(searchText);
+        Utils.displayNoResults(noResultsTracksView, tracksRecyclerView, noTracksView, tracksListAdapter.getItemCount());
 
         return true;
     }

--- a/android/app/src/main/java/org/fossasia/openevent/utils/Utils.java
+++ b/android/app/src/main/java/org/fossasia/openevent/utils/Utils.java
@@ -8,6 +8,7 @@ import android.support.customtabs.CustomTabsIntent;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.Patterns;
+import android.view.View;
 
 import org.fossasia.openevent.OpenEventApp;
 import org.fossasia.openevent.R;
@@ -22,6 +23,16 @@ public class Utils {
 
     public static boolean isEmpty(String string) {
         return string == null || string.trim().length() == 0;
+    }
+
+    public static void displayNoResults(View resultView, View recyclerView, View noView, int count) {
+        if (count != 0) {
+            resultView.setVisibility(View.GONE);
+            recyclerView.setVisibility(View.VISIBLE);
+        } else if (noView.getVisibility() != View.VISIBLE) {
+            resultView.setVisibility(View.VISIBLE);
+            recyclerView.setVisibility(View.GONE);
+        }
     }
 
     public static String checkStringEmpty(String string) {

--- a/android/app/src/main/res/layout/activity_locations.xml
+++ b/android/app/src/main/res/layout/activity_locations.xml
@@ -36,6 +36,15 @@
             tools:listitem="@layout/item_location" />
 
         <TextView
+            android:id="@+id/txt_no_result_loc_sessions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/no_results_found"
+            android:visibility="gone"
+            android:textAppearance="?android:textAppearanceMedium" />
+
+        <TextView
             android:id="@+id/txt_no_sessions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/activity_tracks.xml
+++ b/android/app/src/main/res/layout/activity_tracks.xml
@@ -14,6 +14,16 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <TextView
+            android:id="@+id/txt_no_result_sessions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:text="@string/no_results_found"
+            android:visibility="gone"
+            android:textAppearance="?android:textAppearanceMedium" />
+
+        <TextView
             android:id="@+id/txt_no_sessions"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/list_locations.xml
+++ b/android/app/src/main/res/layout/list_locations.xml
@@ -6,6 +6,16 @@
     android:background="@color/white">
 
     <TextView
+        android:id="@+id/txt_no_result_locations"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="@string/no_results_found"
+        android:visibility="gone"
+        android:textAppearance="?android:textAppearanceMedium" />
+
+    <TextView
         android:id="@+id/txt_no_microlocations"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/list_schedule.xml
+++ b/android/app/src/main/res/layout/list_schedule.xml
@@ -7,6 +7,16 @@
     android:background="@color/white">
 
     <TextView
+        android:id="@+id/txt_no_result_schedule"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="@string/no_results_found"
+        android:visibility="gone"
+        android:textAppearance="?android:textAppearanceMedium" />
+
+    <TextView
         android:id="@+id/txt_no_schedule"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/list_speakers.xml
+++ b/android/app/src/main/res/layout/list_speakers.xml
@@ -7,6 +7,16 @@
     android:background="@color/white">
 
     <TextView
+        android:id="@+id/txt_no_result_speakers"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="@string/no_results_found"
+        android:visibility="gone"
+        android:textAppearance="?android:textAppearanceMedium" />
+
+    <TextView
         android:id="@+id/txt_no_speakers"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/layout/list_tracks.xml
+++ b/android/app/src/main/res/layout/list_tracks.xml
@@ -7,6 +7,16 @@
     android:background="@color/white">
 
     <TextView
+        android:id="@+id/txt_no_result_tracks"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:text="@string/no_results_found"
+        android:visibility="gone"
+        android:textAppearance="?android:textAppearanceMedium" />
+
+    <TextView
         android:id="@+id/txt_no_tracks"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="share_links">Sharing URL</string>
     <string name="time_not_specified">Timings not specified</string>
     <string name="no_results">No Results</string>
+    <string name="no_results_found">No Results Found</string>
 
     <!--Error Titles-->
     <string name="no_internet_connection">No Internet connection</string>


### PR DESCRIPTION
Fixes #1970 
Changes: appropriate text is displayed when there is no result in tracks fragment,speakers fragment,location fragment ,schedule fragment ,TrackSessions Activity and Location Activity

Screenshots for the change: 
![ezgif com-video-to-gif 15](https://user-images.githubusercontent.com/20878145/32273250-aeddb4bc-bf27-11e7-85fb-6da887cf7018.gif)

