### PR TITLE
Fixes #1974 - Add TimeZone for LocalTime

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -26,7 +26,6 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -534,7 +533,6 @@ public class MainActivity extends BaseActivity implements FeedAdapter.AdapterCal
                     DateFormat date = new SimpleDateFormat("z", Locale.getDefault());
                     String localTime = date.format(currentLocalTime);
                     getSupportActionBar().setTitle(getString(R.string.menu_schedule)+" ("+ localTime +")");
-                    Log.e("setting action barTitle", localTime);
                 }
                 else{
                     getSupportActionBar().setTitle(getString(R.string.menu_schedule));

--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -26,9 +26,7 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
-import android.text.Html;
-import android.text.method.LinkMovementMethod;
-import android.view.LayoutInflater;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -36,7 +34,6 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageView;
-import android.widget.TextView;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squareup.otto.Subscribe;
@@ -55,7 +52,6 @@ import org.fossasia.openevent.data.SessionType;
 import org.fossasia.openevent.data.Speaker;
 import org.fossasia.openevent.data.Sponsor;
 import org.fossasia.openevent.data.Track;
-import org.fossasia.openevent.data.extras.Copyright;
 import org.fossasia.openevent.data.extras.SocialLink;
 import org.fossasia.openevent.data.facebook.CommentItem;
 import org.fossasia.openevent.dbutils.RealmDataRepository;
@@ -97,8 +93,14 @@ import org.fossasia.openevent.widget.DialogFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -524,6 +526,20 @@ public class MainActivity extends BaseActivity implements FeedAdapter.AdapterCal
                 break;
             case R.id.nav_schedule:
                 replaceFragment(new ScheduleFragment(), R.string.menu_schedule);
+                boolean isLocal = SharedPreferencesUtil.getBoolean(getString(R.string.showLocalTime), false);
+                if(isLocal) {
+                    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"),
+                            Locale.getDefault());
+                    Date currentLocalTime = calendar.getTime();
+                    DateFormat date = new SimpleDateFormat("z", Locale.getDefault());
+                    String localTime = date.format(currentLocalTime);
+                    getSupportActionBar().setTitle(getString(R.string.menu_schedule)+" ("+ localTime +")");
+                    Log.e("setting action barTitle", localTime);
+                }
+                else{
+                    getSupportActionBar().setTitle(getString(R.string.menu_schedule));
+                }
+
                 break;
             case R.id.nav_speakers:
                 replaceFragment(new SpeakersListFragment(), R.string.menu_speakers);

--- a/android/app/src/main/java/org/fossasia/openevent/activities/SettingsActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SettingsActivity.java
@@ -78,6 +78,11 @@ public class SettingsActivity extends PreferenceActivity implements Preference.O
             }
         } else if (preference.getKey().equals(getResources().getString(R.string.timezone_mode_key))) {
             boolean showLocalTimezone = choice.equals(true);
+            if(showLocalTimezone){
+                SharedPreferencesUtil.putBoolean(getString(R.string.showLocalTime), true);
+            }else{
+                SharedPreferencesUtil.putBoolean(getString(R.string.showLocalTime), false);
+            }
 
             timezonePreference.setChecked(showLocalTimezone);
             DateConverter.setShowLocalTime(showLocalTimezone);

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -288,4 +288,5 @@
     <string name="commenter">Commenter</string>
     <string name="profile_image">Profile Image</string>
     <string name="fields">id,full_picture,message,story,created_time,link,comments</string>
+    <string name="showLocalTime">local_time</string>
 </resources>


### PR DESCRIPTION
Fixes #1974 

Changes: Time zone is now shown to the user in the toolbar if local time switch preference is switched on by the user in settings.

Screenshot for the change: 
Toolbar after the switch preference is on and shows only "Schedule" if switch preference is off.
![temp](https://user-images.githubusercontent.com/21143936/32561361-1809fff4-c4d2-11e7-91f8-299b1a23696e.jpeg)

@heysadboy @Shailesh351 Please review, thanks! :smile: 