### PR TITLE
Fix #1983 app does not crash on selecting or bookmarking a track having empty fields

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -464,9 +464,11 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
 
     private void loadSession(Session session) {
         this.session = session;
-        this.trackColor = Color.parseColor(session.getTrack().getColor());
-        this.fontColor = Color.parseColor(session.getTrack().getFontColor());
-        this.darkColor = Views.getDarkColor(Color.parseColor(session.getTrack().getColor()));
+        if (session.getTrack() != null) {
+            this.trackColor = Color.parseColor(session.getTrack().getColor());
+            this.fontColor = Color.parseColor(session.getTrack().getFontColor());
+            this.darkColor = Views.getDarkColor(Color.parseColor(session.getTrack().getColor()));
+        }
 
         Track track = session.getTrack();
         if (track != null && !Utils.isEmpty(track.getName())) {

--- a/android/app/src/main/java/org/fossasia/openevent/adapters/SessionsListAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/SessionsListAdapter.java
@@ -220,6 +220,8 @@ public class SessionsListAdapter extends BaseRVAdapter<Session, SessionViewHolde
         final int sessionId = session.getId();
 
         holder.sessionBookmarkIcon.setOnClickListener(v -> {
+            if (track == null) return;
+
             if (session.getIsBookmarked()) {
 
                 realmRepo.setBookmark(sessionId, false).subscribe();

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/AboutFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/AboutFragment.java
@@ -343,7 +343,7 @@ public class AboutFragment extends BaseFragment {
             for (String eventDate : dateList) {
                 boolean headerCheck = false;
                 for (Session bookmarkedSession : bookmarked) {
-                    if (bookmarkedSession.getStartDate().equals(eventDate)) {
+                    if (bookmarkedSession.getStartDate() != null && bookmarkedSession.getStartDate().equals(eventDate)) {
                         if (!headerCheck) {
                             String headerDate = "Invalid";
                             try {


### PR DESCRIPTION
Fixes #1983 

Changes: app does not crash on selecting or bookmarking a track having empty fields

Screenshots for the change: 
![ezgif com-video-to-gif 20](https://user-images.githubusercontent.com/20878145/32659425-b88f4d6c-c644-11e7-8733-15a4f704b7e9.gif)
