### PR TITLE
Fix #1988 cursor is positioned at the end of editText

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/auth/EditProfileActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/auth/EditProfileActivity.java
@@ -264,8 +264,10 @@ public class EditProfileActivity extends AppCompatActivity {
         String lastName = user.getLastName();
         String avatarUrl = user.getAvatarUrl();
 
-        if (firstName != null)
+        if (firstName != null) {
             firstNameInput.setText(firstName.trim());
+            firstNameInput.setSelection(firstName.length());
+        }
         if (lastName != null)
             lastNameInput.setText(lastName.trim());
 


### PR DESCRIPTION
Fixes #1988 

Changes: cursor is positioned at the end of editText

Screenshots for the change: 
![screenshot_20171111-004818](https://user-images.githubusercontent.com/20878145/32675089-aa30507c-c67b-11e7-9cf2-aff65dc61c19.png)
