### PR TITLE
fix : Null object error fixed in track details items

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -464,13 +464,13 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
 
     private void loadSession(Session session) {
         this.session = session;
-        this.trackColor = Color.parseColor(session.getTrack().getColor());
-        this.fontColor = Color.parseColor(session.getTrack().getFontColor());
-        this.darkColor = Views.getDarkColor(Color.parseColor(session.getTrack().getColor()));
-
         Track track = session.getTrack();
+
         if (track != null && !Utils.isEmpty(track.getName())) {
             this.trackName = track.getName();
+            this.trackColor = Color.parseColor(track.getColor());
+            this.fontColor = Color.parseColor(track.getFontColor());
+            this.darkColor = Views.getDarkColor(Color.parseColor(track.getColor()));
             hasTrack = true;
         }
 

--- a/android/app/src/main/java/org/fossasia/openevent/adapters/SessionsListAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/SessionsListAdapter.java
@@ -179,9 +179,12 @@ public class SessionsListAdapter extends BaseRVAdapter<Session, SessionViewHolde
         holder.sessionTime.setText(String.format("%s - %s",
                 DateConverter.formatDateWithDefault(DateConverter.FORMAT_12H, session.getStartsAt()),
                 DateConverter.formatDateWithDefault(DateConverter.FORMAT_12H, session.getEndsAt())));
+
         if(session.getMicrolocation() != null) {
             String locationName = Utils.checkStringEmpty(session.getMicrolocation().getName());
             holder.sessionLocation.setText(locationName);
+        } else {
+            holder.sessionLocation.setText(context.getString(R.string.location_not_decided));
         }
 
         Observable.just(session.getSpeakers())


### PR DESCRIPTION
Changes: 'To be decided' microlocations were left blank in items, so added a 'Not yet decided' line.
App doesn't crash on clicking certain items in the tracks list. (which it used to)

Screenshots for the change: 
![screenshot_20171117-123206](https://user-images.githubusercontent.com/28607714/32934864-648a2206-cb93-11e7-9e34-3fda9ae959b4.png)
