### PR TITLE
Fix #1977-Improve visibility of Snackbar action text.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
@@ -6,6 +6,7 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.os.Build;
 import android.support.design.widget.Snackbar;
+import android.support.v4.graphics.ColorUtils;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.Button;
@@ -23,6 +24,7 @@ import org.fossasia.openevent.utils.ConstantStrings;
 import org.fossasia.openevent.utils.DateConverter;
 import org.fossasia.openevent.utils.NotificationUtil;
 import org.fossasia.openevent.utils.Utils;
+import org.fossasia.openevent.utils.Views;
 import org.fossasia.openevent.utils.WidgetUpdater;
 
 import butterknife.BindView;
@@ -103,14 +105,16 @@ public class DayScheduleViewHolder extends RecyclerView.ViewHolder {
                     slot_bookmark.setImageResource(R.drawable.ic_bookmark_border_white_24dp);
 
                     if ("MainActivity".equals(context.getClass().getSimpleName())) {
-                        Snackbar.make(slot_content, R.string.removed_bookmark, Snackbar.LENGTH_LONG)
+                        Snackbar snackbar = Snackbar.make(slot_content, R.string.removed_bookmark, Snackbar.LENGTH_LONG)
                                 .setAction(R.string.undo, view -> {
 
                                     realmRepo.setBookmark(sessionId, true).subscribe();
                                     slot_bookmark.setImageResource(R.drawable.ic_bookmark_white_24dp);
 
                                     WidgetUpdater.updateWidget(context);
-                                }).show();
+                                })
+                                .setActionTextColor(ColorUtils.setAlphaComponent(Views.getAccentColor(context), 220));
+                        snackbar.show();
                     } else {
                         Snackbar.make(slot_content, R.string.removed_bookmark, Snackbar.LENGTH_SHORT).show();
                     }

--- a/android/app/src/main/java/org/fossasia/openevent/utils/Views.java
+++ b/android/app/src/main/java/org/fossasia/openevent/utils/Views.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.support.annotation.ColorInt;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.widget.EdgeEffectCompat;
 import android.support.v4.widget.NestedScrollView;
@@ -23,6 +24,8 @@ import android.view.ViewTreeObserver;
 import android.widget.EdgeEffect;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import org.fossasia.openevent.R;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -193,5 +196,9 @@ public final class Views {
         EdgeEffect effect = (EdgeEffect) field.get(edgeEffect);
         if (effect != null)
             effect.setColor(color);
+    }
+
+    public static int getAccentColor(final Context context) {
+        return ContextCompat.getColor(context, R.color.color_accent);
     }
 }


### PR DESCRIPTION
Fixes #1977 

Changes: Adjust opacity of the text displayed.

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/33699269-170d818a-db38-11e7-9b5e-a25368644a78.png)
