### PR TITLE
Fix #2019 improve UI of speakers fragment

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/SpeakersListAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/SpeakersListAdapter.java
@@ -8,9 +8,13 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import org.fossasia.openevent.R;
+import org.fossasia.openevent.adapters.viewholders.HeaderViewHolder;
 import org.fossasia.openevent.adapters.viewholders.SpeakerViewHolder;
 import org.fossasia.openevent.data.Speaker;
+import org.fossasia.openevent.utils.ConstantStrings;
+import org.fossasia.openevent.utils.SharedPreferencesUtil;
 import org.fossasia.openevent.utils.Utils;
+import org.fossasia.openevent.views.stickyheadersrecyclerview.StickyRecyclerHeadersAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,11 +27,14 @@ import timber.log.Timber;
  * User: MananWason
  * Date: 11-06-2015
  */
-public class SpeakersListAdapter extends BaseRVAdapter<Speaker, SpeakerViewHolder> {
+public class SpeakersListAdapter extends BaseRVAdapter<Speaker, SpeakerViewHolder> implements StickyRecyclerHeadersAdapter<HeaderViewHolder> {
 
     private List<String> distinctOrgs = new ArrayList<>();
     private List<String> distinctCountry = new ArrayList<>();
+    private List<String> Orgs = new ArrayList<>();
+    private List<String> Country = new ArrayList<>();
 
+    private int sortType;
     private Context context;
     private List<Speaker> copyOfSpeakers = new ArrayList<>();
 
@@ -110,6 +117,57 @@ public class SpeakersListAdapter extends BaseRVAdapter<Speaker, SpeakerViewHolde
 
     public int getDistinctCountry(){
         return distinctCountry.size();
+    }
+
+    @Override
+    public long getHeaderId(int position) {
+        sortType = SharedPreferencesUtil.getInt(ConstantStrings.PREF_SORT_SPEAKER, 0);
+        Speaker current = getItem(position);
+
+        String name = current.getName();
+        String organisation = current.getOrganisation();
+        String country = current.getCountry();
+
+        if (sortType == 0)
+            return name.toUpperCase().charAt(0);
+        else if (sortType == 1) {
+            if (!Orgs.contains(organisation)) {
+                Orgs.add(organisation);
+            }
+            return Orgs.indexOf(organisation);
+        } else {
+            if (!Country.contains(country)) {
+                Country.add(country);
+            }
+            return Country.indexOf(country);
+        }
+    }
+
+    @Override
+    public HeaderViewHolder onCreateHeaderViewHolder(ViewGroup parent) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.recycler_view_header, parent, false);
+        return new HeaderViewHolder(view);
+    }
+
+    @Override
+    public void onBindHeaderViewHolder(HeaderViewHolder holder, int position) {
+        sortType = SharedPreferencesUtil.getInt(ConstantStrings.PREF_SORT_SPEAKER, 0);
+        String speakerData;
+
+        if (sortType == 0)
+            speakerData = Utils.checkStringEmpty(getItem(position).getName());
+        else if (sortType == 1)
+            speakerData = Utils.checkStringEmpty(getItem(position).getOrganisation());
+        else
+            speakerData = Utils.checkStringEmpty(getItem(position).getCountry());
+
+        if (!TextUtils.isEmpty(speakerData) && sortType == 0)
+            holder.header.setText(String.valueOf(speakerData.toUpperCase().charAt(0)));
+        else if (!TextUtils.isEmpty(speakerData) && (sortType == 1 || sortType == 2))
+            holder.header.setText(String.valueOf(speakerData));
+        else
+            holder.header.setText(String.valueOf("#"));
     }
 
 }

--- a/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/fragments/SpeakersListFragment.java
@@ -38,6 +38,7 @@ import org.fossasia.openevent.utils.SharedPreferencesUtil;
 import org.fossasia.openevent.utils.Utils;
 import org.fossasia.openevent.utils.Views;
 import org.fossasia.openevent.views.MarginDecoration;
+import org.fossasia.openevent.views.stickyheadersrecyclerview.StickyRecyclerHeadersDecoration;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -104,10 +105,17 @@ public class SpeakersListFragment extends BaseFragment implements SearchView.OnQ
 
         speakersListAdapter = new SpeakersListAdapter(speakers, getActivity());
 
-        speakersRecyclerView.addItemDecoration(new MarginDecoration(getContext()));
         speakersRecyclerView.setHasFixedSize(true);
         speakersRecyclerView.setAdapter(speakersListAdapter);
         speakersRecyclerView.setLayoutManager(gridLayoutManager);
+        final StickyRecyclerHeadersDecoration headersDecoration = new StickyRecyclerHeadersDecoration(speakersListAdapter);
+        speakersRecyclerView.addItemDecoration(headersDecoration);
+        speakersListAdapter.registerAdapterDataObserver(new RecyclerView.AdapterDataObserver() {
+            @Override
+            public void onChanged() {
+                headersDecoration.invalidateHeaders();
+            }
+        });
     }
 
     private void loadData() {

--- a/android/app/src/main/res/layout/item_speaker.xml
+++ b/android/app/src/main/res/layout/item_speaker.xml
@@ -12,7 +12,7 @@
         xmlns:card_view="http://schemas.android.com/apk/res-auto"
         card_view:cardElevation="6dp"
         card_view:cardCornerRadius="2dp"
-        card_view:cardUseCompatPadding="true"
+        android:layout_margin="@dimen/layout_margin_medium"
         android:layout_height="match_parent">
         <ImageView
             android:id="@+id/speakers_list_image"


### PR DESCRIPTION
Fixes #2019 

Changes: Removed grid layout from the speakers fragment and used recyclerview with sticky headers

Screenshots for the change: 
![ezgif com-video-to-gif 24](https://user-images.githubusercontent.com/20878145/34078519-fa0b7c24-e341-11e7-8535-02b086b085de.gif)
