### PR TITLE
Fix #2018 fix padding in copyright dialog

### DIFF
--- a/android/app/src/main/res/layout/copyright_dialog.xml
+++ b/android/app/src/main/res/layout/copyright_dialog.xml
@@ -1,27 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:cardCornerRadius="2dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
     <TextView
         android:id="@+id/holder_textview"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textAlignment="center"
-        android:background="@color/color_primary"
-        android:textColor="@color/card_title"
-        android:textSize="20sp" />
+        style="@style/CardContent.Header"
+        tools:text="Header"/>
+
     <TextView
         android:id="@+id/licence"
-        android:layout_marginTop="15dp"
-        android:padding="5dp"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        style="@style/CardContent"
+        tools:text="License"/>
+
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:padding="5dp"
-        android:id="@+id/licence_url"/>
+        android:id="@+id/licence_url"
+        style="@style/CardContent"
+        tools:text="License URL"/>
 
-</LinearLayout>
+    </LinearLayout>
+
+</android.support.v7.widget.CardView>


### PR DESCRIPTION
Fixes #2018 

Changes: fixed padding in copyright dialog by using the styles CardContent.Header and CardContent

Screenshots for the change: 
![screenshot_20171218-135626](https://user-images.githubusercontent.com/20878145/34096483-76c40ee8-e3fb-11e7-9940-d7defa0971b6.png)
