### PR TITLE
Fix #2063 - App crashes for blank search query.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SearchActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SearchActivity.java
@@ -100,7 +100,7 @@ public class SearchActivity extends BaseActivity implements SearchView.OnQueryTe
 
     @Override
     public boolean onQueryTextChange(String query) {
-        if (query != null) {
+        if (!TextUtils.isEmpty(query)) {
             searchQuery(query);
             searchText = query;
         } else {


### PR DESCRIPTION
Fixes #2063 

Changes: Added check for empty text query so that the app doesn't crash. 

Screenshots for the change: 
