### PR TITLE
Fixed #2139 - Snackbar is displayed only once while bookmarking

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
@@ -132,7 +132,6 @@ public class DayScheduleViewHolder extends RecyclerView.ViewHolder {
                     slot_bookmark.setImageResource(R.drawable.ic_bookmark_white_24dp);
                     slot_bookmark.setColorFilter(storedColor,PorterDuff.Mode.SRC_ATOP);
 
-                    Snackbar.make(slot_content, R.string.added_bookmark, Snackbar.LENGTH_SHORT).show();
                 }
                 WidgetUpdater.updateWidget(context);
             });


### PR DESCRIPTION
Fixes #2139

Changes: Since there is already a subscriber which shows the snackbar with "bookmark added" message on successful completion of the completable, there is no need to show the snackbar message again. So removed that line which called the snackbar again.


