### PR TITLE
fix : unnecessary elements in shared text have disappeared

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/SessionDetailActivity.java
@@ -358,16 +358,26 @@ public class SessionDetailActivity extends BaseActivity implements AppBarLayout.
                 return true;
 
             case R.id.action_share:
+                StringBuilder speakersNameBuilder  = new StringBuilder();
+                boolean firstSpeaker = true;
+                for (Speaker speaker : session.getSpeakers()) {
+                    if (!firstSpeaker) {
+                        speakersNameBuilder.append(", ");
+                    }
+                    speakersNameBuilder.append(speaker.getName());
+                    firstSpeaker = false;
+                }
+
                 String startTime = DateConverter.formatDateWithDefault(DateConverter.FORMAT_DATE_COMPLETE, session.getStartsAt());
                 String endTime = DateConverter.formatDateWithDefault(DateConverter.FORMAT_DATE_COMPLETE, session.getEndsAt());
-                String shareText = String.format("Session Track: %s \n" +
-                                "Title: %s \n" +
-                                "Start Time: %s \n" +
-                                "End Time: %s\n" +
-                                "Speakers: %s\n" +
-                                "Location: %s",
-                        trackName, title, startTime, endTime, StringUtils.join(speakers, ", "), location) +
-                        "\nDescription: " + Views.fromHtml(session.getLongAbstract());
+                String shareText = String.format(getResources().getString(R.string.session_track_details) + " %s \n" +
+                                getResources().getString(R.string.title_details) + " %s \n" +
+                                getResources().getString(R.string.start_time_details) + " %s \n" +
+                                getResources().getString(R.string.end_time_details) + " %s \n" +
+                                getResources().getString(R.string.speakers_details) + " %s \n" +
+                                getResources().getString(R.string.location_details) + " %s ",
+                        trackName, title, startTime, endTime, speakersNameBuilder.toString(), location) +
+                        "\n"+getResources().getString(R.string.description_details) + " " + Views.fromHtml(session.getShortAbstract());
 
                 Intent sendIntent = new Intent();
                 sendIntent.setAction(Intent.ACTION_SEND);

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -301,4 +301,14 @@
     <string name="speakers_bio">About me</string>
     <string name="social_media">Social media</string>
     <string name="sessions_title_card">Sessions</string>
+
+    <!--Session-detail-strings-->
+    <string name="session_track_details">Session Track :</string>
+    <string name="title_details">Title :</string>
+    <string name="start_time_details">Start Time :</string>
+    <string name="end_time_details">End Time :</string>
+    <string name="location_details">Location :</string>
+    <string name="speakers_details">Speaker(s) :</string>
+    <string name="description_details">Description :</string>
+
 </resources>


### PR DESCRIPTION
Fixes #1971 

Changes: The Description part has been changed to a shorter abstract version of it and the Speakers names have been filtered out.

Screenshots for the change: 
![screenshot_20180119-041703](https://user-images.githubusercontent.com/28607714/35125605-42f91084-fcd0-11e7-8087-44a7e41eb679.png)

