### PR TITLE
fix: undo option is shown when bookmark is added in schedule fragment

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/viewholders/DayScheduleViewHolder.java
@@ -31,7 +31,6 @@ import butterknife.ButterKnife;
 import io.realm.RealmChangeListener;
 import timber.log.Timber;
 
-import static org.fossasia.openevent.listeners.BookmarkStatus.Status.CODE_BLANK;
 import static org.fossasia.openevent.listeners.BookmarkStatus.Status.CODE_ERROR;
 import static org.fossasia.openevent.listeners.BookmarkStatus.Status.CODE_UNDO_ADDED;
 import static org.fossasia.openevent.listeners.BookmarkStatus.Status.CODE_UNDO_REMOVED;
@@ -115,7 +114,7 @@ public class DayScheduleViewHolder extends RecyclerView.ViewHolder {
                     NotificationUtil.createNotification(session, context).subscribe(
                             () -> {
                                 if (onBookmarkSelectedListener != null)
-                                    onBookmarkSelectedListener.showSnackbar(new BookmarkStatus(-1, -1, CODE_BLANK));
+                                    onBookmarkSelectedListener.showSnackbar(new BookmarkStatus(storedColor, sessionId, CODE_UNDO_ADDED));
                             },
                             throwable -> {
                                 if (onBookmarkSelectedListener != null)


### PR DESCRIPTION
Fixes #2168 

Changes: undo option is shown when bookmark is added in schedule fragment

Screenshots for the change: 
![screenshot_20180121-161036](https://user-images.githubusercontent.com/20878145/35193242-daefdafc-fec5-11e7-8c37-a325455c465e.png)
