### PR TITLE
fix: Bookmarked events are visible in About Fragment

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/adapters/GlobalSearchAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/adapters/GlobalSearchAdapter.java
@@ -41,10 +41,11 @@ public class GlobalSearchAdapter extends BaseRVAdapter<Object, RecyclerView.View
     public GlobalSearchAdapter(List<Object> dataList, Context context) {
         super(dataList);
         this.context = context;
+        filteredResultList = dataList;
     }
 
-    public void setCopyOfSearches(List<Object> dataList){
-        this.filteredResultList = dataList;
+    public void setCopyOfSearches(List<Object> dataList) {
+        filteredResultList = dataList;
     }
 
     @Override
@@ -97,7 +98,7 @@ public class GlobalSearchAdapter extends BaseRVAdapter<Object, RecyclerView.View
             case SPEAKER:
                 View speaker = inflater.inflate(R.layout.search_item_speaker, parent, false);
                 resultHolder = new SpeakerViewHolder(speaker, context);
-                ((SpeakerViewHolder)resultHolder).setIsImageCircle(true);
+                ((SpeakerViewHolder) resultHolder).setIsImageCircle(true);
                 break;
             case LOCATION:
                 View location = inflater.inflate(R.layout.item_location, parent, false);


### PR DESCRIPTION
Fixes #2185 

Changes:Bookmarked events are visible in About Fragment

Screenshots for the change: 
![screenshot_20180121-223248](https://user-images.githubusercontent.com/20878145/35196689-96736dd6-fefb-11e7-8abd-d30c80dfa8d8.png)
