### PR TITLE
fix: Fetch values from JSON when error 404 occurs

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/activities/MainActivity.java
@@ -694,8 +694,10 @@ public class MainActivity extends BaseActivity implements FeedAdapter.OpenCommen
     @Subscribe
     public void handleResponseEvent(RetrofitResponseEvent responseEvent) {
         Integer statusCode = responseEvent.getStatusCode();
-        if (statusCode.equals(404))
+        if (statusCode.equals(404)) {
             showErrorDialog(getResources().getString(R.string.http_error), statusCode + "\n" + getResources().getString(R.string.api_not_found));
+            downloadFromAssets();
+        }
     }
 
     @Subscribe


### PR DESCRIPTION
Fixes #2188 

Changes: When error 404 occurs instead of creating an empty app with no values,values are fetched from the JSON file stored in the app

Screenshots for the change: N/A
