### PR TITLE
Fix #2203 - Add some bottom padding to About Me card.

### DIFF
--- a/android/app/src/main/res/layout/activity_speakers.xml
+++ b/android/app/src/main/res/layout/activity_speakers.xml
@@ -132,7 +132,6 @@
                         android:id="@+id/tv_speaker_bio_title"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="@dimen/layout_margin_medium"
                         android:layout_marginTop="@dimen/layout_margin_medium"
                         android:padding="@dimen/padding_medium"
                         android:text="@string/speakers_bio"
@@ -142,10 +141,7 @@
                         android:id="@+id/speaker_bio"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:paddingEnd="@dimen/padding_medium"
-                        android:paddingLeft="@dimen/padding_medium"
-                        android:paddingRight="@dimen/padding_medium"
-                        android:paddingStart="@dimen/padding_medium"
+                        android:padding="@dimen/padding_medium"
                         tools:text="Paresh Mayani, Technical Lead @ Android" />
 
                 </LinearLayout>


### PR DESCRIPTION
Fixes #2203 

Changes: Add 8dp bottom padding to about me card.

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/22395998/35393471-13f3e27e-020b-11e8-82b8-227cdadbcd35.png)
