### PR TITLE
fix: correct text size of the toolbar text is displayed in landscape

### DIFF
--- a/android/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/android/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -37,6 +37,7 @@
                     style="@style/ToolbarTheme"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
+                    app:titleTextAppearance="@style/ToolbarTitle"
                     app:popupTheme="@style/PopupOverlay" />
 
                 <ProgressBar

--- a/android/app/src/main/res/layout/activity_locations.xml
+++ b/android/app/src/main/res/layout/activity_locations.xml
@@ -21,6 +21,7 @@
             style="@style/ToolbarTheme"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            app:titleTextAppearance="@style/ToolbarTitle"
             app:popupTheme="@style/PopupOverlay" />
     </android.support.design.widget.AppBarLayout>
 

--- a/android/app/src/main/res/layout/activity_login.xml
+++ b/android/app/src/main/res/layout/activity_login.xml
@@ -17,6 +17,7 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            app:titleTextAppearance="@style/ToolbarTitle"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -32,6 +32,7 @@
                 style="@style/ToolbarTheme"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                app:titleTextAppearance="@style/ToolbarTitle"
                 app:popupTheme="@style/PopupOverlay" />
 
             <ProgressBar

--- a/android/app/src/main/res/layout/activity_sessions_detail.xml
+++ b/android/app/src/main/res/layout/activity_sessions_detail.xml
@@ -34,6 +34,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"
+                app:titleTextAppearance="@style/ToolbarTitle"
                 app:popupTheme="@style/AppTheme.PopupOverlay" />
 
             <LinearLayout

--- a/android/app/src/main/res/layout/activity_settings.xml
+++ b/android/app/src/main/res/layout/activity_settings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@id/content_frame"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -10,8 +11,8 @@
         android:id="@+id/setting_toolbar"
         style="@style/ToolbarTheme"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize" />
+        android:layout_height="?attr/actionBarSize"
+        app:titleTextAppearance="@style/ToolbarTitle" />
 
     <ListView
         android:id="@android:id/list"

--- a/android/app/src/main/res/layout/activity_sign_up.xml
+++ b/android/app/src/main/res/layout/activity_sign_up.xml
@@ -16,6 +16,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            app:titleTextAppearance="@style/ToolbarTitle"
             app:popupTheme="@style/AppTheme.PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>

--- a/android/app/src/main/res/layout/activity_speakers.xml
+++ b/android/app/src/main/res/layout/activity_speakers.xml
@@ -59,6 +59,7 @@
                 android:id="@+id/toolbar_speakers"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
+                app:titleTextAppearance="@style/ToolbarTitle"
                 app:layout_collapseMode="pin" />
 
             <LinearLayout

--- a/android/app/src/main/res/layout/activity_tracks.xml
+++ b/android/app/src/main/res/layout/activity_tracks.xml
@@ -53,6 +53,7 @@
             style="@style/ToolbarTheme"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
+            app:titleTextAppearance="@style/ToolbarTitle"
             app:popupTheme="@style/PopupOverlay" />
 
     </android.support.design.widget.AppBarLayout>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -99,6 +99,10 @@
         <item name="android:textSize">@dimen/text_size_expanded_title</item>
     </style>
 
+    <style name="ToolbarTitle" parent="@style/TextAppearance.Widget.AppCompat.Toolbar.Title">
+        <item name="android:textSize">@dimen/heading_text_size</item>
+    </style>
+
     <!--Change toolbar colors -->
     <style name="ToolbarTheme" parent="Widget.AppCompat.Toolbar">
         <item name="android:background">@color/color_primary</item>


### PR DESCRIPTION
Fixes #2036 

Changes: correct text size of the toolbar text is displayed in landscape mode in all activities

Screenshots for the change: 
![screenshot_20180125-235822](https://user-images.githubusercontent.com/20878145/35405346-d641a350-022b-11e8-955b-6629b12ee684.png)
![screenshot_20180125-235838](https://user-images.githubusercontent.com/20878145/35405349-d7ad6030-022b-11e8-9cf2-0592c40509e7.png)
