### PR TITLE
Fixes #2260 fixedProfileCrash added permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.fossasia.openevent">
+    package="org.fossasia.openevent"
+    android:installLocation="preferExternal">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.fossasia.openevent"
-    android:installLocation="preferExternal">
+    package="org.fossasia.openevent">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/android/app/src/main/java/org/fossasia/openevent/core/auth/profile/EditProfileActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/auth/profile/EditProfileActivity.java
@@ -205,11 +205,8 @@ public class EditProfileActivity extends AppCompatActivity {
     }
     private boolean checkIfAlreadyhavePermission() {
         int result = ContextCompat.checkSelfPermission(this, Manifest.permission.GET_ACCOUNTS);
-        if (result == PackageManager.PERMISSION_GRANTED) {
-            return true;
-        } else {
-            return false;
-        }
+        return result == PackageManager.PERMISSION_GRANTED;
+
     }
     private void requestForSpecificPermission() {
         ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 101);
@@ -221,6 +218,7 @@ public class EditProfileActivity extends AppCompatActivity {
             case 101:
                 if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     showFileChooser();
+                    //granted
                     Toast.makeText(this,getString(R.string.permissions_given),Toast.LENGTH_LONG).show();
                 } else {
                     Toast.makeText(this,getString(R.string.permission_required),Toast.LENGTH_SHORT).show();
@@ -229,6 +227,7 @@ public class EditProfileActivity extends AppCompatActivity {
                 break;
             default:
                 super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+                break;
         }
     }
     @Override

--- a/android/app/src/main/java/org/fossasia/openevent/core/auth/profile/EditProfileActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/auth/profile/EditProfileActivity.java
@@ -1,14 +1,19 @@
 package org.fossasia.openevent.core.auth.profile;
 
+import android.Manifest;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -84,7 +89,8 @@ public class EditProfileActivity extends AppCompatActivity {
         });
 
         avatar.setOnClickListener(v -> {
-            showFileChooser();
+          androidVersionCheck();
+
         });
 
         save.setOnClickListener(v -> {
@@ -180,13 +186,51 @@ public class EditProfileActivity extends AppCompatActivity {
         }
     }
 
+    private void androidVersionCheck()
+    {
+        int MyVersion = Build.VERSION.SDK_INT;
+        if (MyVersion > Build.VERSION_CODES.LOLLIPOP_MR1) {
+            if (!checkIfAlreadyhavePermission()) {
+                requestForSpecificPermission();
+            }
+            else showFileChooser();
+        }
+        else showFileChooser();
+    }
     private void showFileChooser() {
         Intent intent = new Intent();
         intent.setType("image/*");
         intent.setAction(Intent.ACTION_GET_CONTENT);
         startActivityForResult(Intent.createChooser(intent, "Select Image"), PICK_IMAGE_REQUEST);
     }
+    private boolean checkIfAlreadyhavePermission() {
+        int result = ContextCompat.checkSelfPermission(this, Manifest.permission.GET_ACCOUNTS);
+        if (result == PackageManager.PERMISSION_GRANTED) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    private void requestForSpecificPermission() {
+        ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 101);
+    }
 
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        switch (requestCode) {
+            case 101:
+                if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    showFileChooser();
+                    Toast.makeText(this,getString(R.string.permissions_given),Toast.LENGTH_LONG).show();
+                } else {
+                    Toast.makeText(this,getString(R.string.permission_required),Toast.LENGTH_SHORT).show();
+                    //not granted
+                }
+                break;
+            default:
+                super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -331,4 +331,6 @@
     <string name="twitter_feed">Twitter Feed</string>
     <string name="featured_speakers_header">Featured Speakers</string>
 
+    <string name="permission_required">Permission required</string>
+
 </resources>


### PR DESCRIPTION
Fixes #2260 . app crash when pickingUp image from gallery  e.g.  #2260 


Changes: [Permission added for picking image 
                 added     
<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
and some code for checking android version in editprofileActivity


Screenshots for the change: 
![ezgif com-video-to-gif 7](https://user-images.githubusercontent.com/31108317/35746872-620fd634-086e-11e8-970d-4d6804d9b617.gif)

