### PR TITLE
Fixes #2318 Events bookmarked from Featured Speakers are now visible in AboutFragment.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/about/AboutFragmentViewModel.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/about/AboutFragmentViewModel.java
@@ -34,6 +34,7 @@ public class AboutFragmentViewModel extends ViewModel {
     private LiveData<Event> eventLiveData;
     private LiveData<List<Speaker>> featuredSpeakers;
     private MutableLiveData<Bitmap> eventLogo;
+    private Long numberOfBookmarkedSessions;
 
     public AboutFragmentViewModel() {
         realmRepo = RealmDataRepository.getDefaultInstance();
@@ -58,10 +59,12 @@ public class AboutFragmentViewModel extends ViewModel {
     }
 
     public LiveData<List<Object>> getBookmarkedSessions() {
-        if (sessions == null) {
+        if (sessions == null || numberOfBookmarkedSessions != realmRepo.getBookMarkedSessionsLength()) {
             LiveRealmData<Session> sessionLiveRealmData = RealmDataRepository.asLiveData(realmRepo.getBookMarkedSessions());
             sessions = Transformations.map(sessionLiveRealmData, this::getSessionsList);
+            numberOfBookmarkedSessions = realmRepo.getBookMarkedSessionsLength();
         }
+
         return sessions;
     }
 

--- a/android/app/src/main/java/org/fossasia/openevent/data/repository/RealmDataRepository.java
+++ b/android/app/src/main/java/org/fossasia/openevent/data/repository/RealmDataRepository.java
@@ -406,6 +406,10 @@ public class RealmDataRepository {
         return realm.where(Session.class).equalTo("isBookmarked", true).findAllAsync();
     }
 
+    public long getBookMarkedSessionsLength() {
+        return realm.where(Session.class).equalTo("isBookmarked", true).count();
+    }
+
     public List<Session> getBookMarkedSessionsSync() {
         Realm realm = Realm.getDefaultInstance();
         RealmResults<Session> sessions = realm.where(Session.class).equalTo("isBookmarked", true).findAll();


### PR DESCRIPTION
Fixes #2318

Changes: Before when the onResume() method was called in AboutFragment.java, it doesn't update the bookMarksListAdapter with the new data. Now call to the function getBookmarkedSessions() first checks the new data and then update the list for the bookMarksListAdapter.


