### PR TITLE
Fix #2326 - Move Twitter and Facebook feed under one fragment.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/FeedFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/FeedFragment.java
@@ -1,0 +1,64 @@
+package org.fossasia.openevent.core.feed;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.design.widget.TabLayout;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.fossasia.openevent.R;
+import org.fossasia.openevent.common.ui.base.BaseFragment;
+import org.fossasia.openevent.common.ui.image.OnImageZoomListener;
+import org.fossasia.openevent.core.feed.facebook.FacebookFeedFragment;
+import org.fossasia.openevent.core.feed.twitter.TwitterFeedFragment;
+
+import butterknife.BindView;
+
+public class FeedFragment extends BaseFragment {
+
+    @BindView(R.id.viewpager)
+    protected ViewPager viewPager;
+    @BindView(R.id.tabLayout)
+    protected TabLayout feedTabLayout;
+
+    private OpenCommentsDialogListener openCommentsDialogListener;
+    private OnImageZoomListener onImageZoomListener;
+
+    public static FeedFragment getInstance(OpenCommentsDialogListener openCommentsDialogListener,
+                                           OnImageZoomListener onImageZoomListener) {
+        FeedFragment feedFragment = new FeedFragment();
+        feedFragment.openCommentsDialogListener = openCommentsDialogListener;
+        feedFragment.onImageZoomListener = onImageZoomListener;
+
+        return feedFragment;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+
+        setUpViewPager(viewPager);
+        feedTabLayout.setupWithViewPager(viewPager);
+
+        return view;
+    }
+
+    private void setUpViewPager(ViewPager viewPager) {
+        FeedViewPagerAdapter feedViewPagerAdapter = new FeedViewPagerAdapter(getChildFragmentManager());
+        feedViewPagerAdapter.addFragment(FacebookFeedFragment.getInstance(openCommentsDialogListener, onImageZoomListener), getString(R.string.facebook));
+        feedViewPagerAdapter.addFragment(TwitterFeedFragment.getInstance(onImageZoomListener), getString(R.string.twitter));
+        feedViewPagerAdapter.notifyDataSetChanged();
+
+        viewPager.setAdapter(feedViewPagerAdapter);
+    }
+
+    @Override
+    protected int getLayoutResource() {
+        return R.layout.fragment_feed_main;
+    }
+
+}

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/FeedViewPagerAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/FeedViewPagerAdapter.java
@@ -1,0 +1,41 @@
+package org.fossasia.openevent.core.feed;
+
+
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FeedViewPagerAdapter extends FragmentPagerAdapter {
+
+    private List<Fragment> fragmentList = new ArrayList<>();
+    private List<String> fragmentTitleList = new ArrayList<>();
+
+    public FeedViewPagerAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return fragmentList.get(position);
+    }
+
+    public void addFragment(final Fragment fragment, final String title) {
+        fragmentList.add(fragment);
+        fragmentTitleList.add(title);
+    }
+
+    @Nullable
+    @Override
+    public CharSequence getPageTitle(int position) {
+        return fragmentTitleList.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return fragmentList.size();
+    }
+}

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/OpenCommentsDialogListener.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/OpenCommentsDialogListener.java
@@ -1,0 +1,9 @@
+package org.fossasia.openevent.core.feed;
+
+import org.fossasia.openevent.core.feed.facebook.api.CommentItem;
+
+import java.util.List;
+
+public interface OpenCommentsDialogListener {
+    void openCommentsDialog(List<CommentItem> commentItems);
+}

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedAdapter.java
@@ -19,6 +19,7 @@ import com.squareup.picasso.Picasso;
 
 import org.fossasia.openevent.R;
 import org.fossasia.openevent.common.ui.base.BaseRVAdapter;
+import org.fossasia.openevent.core.feed.OpenCommentsDialogListener;
 import org.fossasia.openevent.core.feed.facebook.api.CommentItem;
 import org.fossasia.openevent.core.feed.facebook.api.FeedItem;
 import org.fossasia.openevent.common.ui.image.OnImageZoomListener;
@@ -33,7 +34,7 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 import timber.log.Timber;
 
-public class FeedAdapter extends BaseRVAdapter<FeedItem, FeedAdapter.RecyclerViewHolder> {
+public class FacebookFeedAdapter extends BaseRVAdapter<FeedItem, FacebookFeedAdapter.RecyclerViewHolder> {
 
     private List<FeedItem> feedItems;
     private Context context;
@@ -85,7 +86,7 @@ public class FeedAdapter extends BaseRVAdapter<FeedItem, FeedAdapter.RecyclerVie
         }
     }
 
-    public FeedAdapter(Context context, OpenCommentsDialogListener openCommentsDialogListener, List<FeedItem> feedItems) {
+    public FacebookFeedAdapter(Context context, OpenCommentsDialogListener openCommentsDialogListener, List<FeedItem> feedItems) {
         super(feedItems);
         this.feedItems = feedItems;
         this.context = context;
@@ -155,10 +156,6 @@ public class FeedAdapter extends BaseRVAdapter<FeedItem, FeedAdapter.RecyclerVie
 
         int comments = feedItem.getComments() != null ? feedItem.getComments().getData().size() : 0;
         holder.getComments.setText(context.getString(R.string.comments_value, comments));
-    }
-
-    public interface OpenCommentsDialogListener {
-        void openCommentsDialog(List<CommentItem> commentItems);
     }
 
     public void setOnImageZoomListener(OnImageZoomListener onImageZoomListener) {

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedFragmentViewModel.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedFragmentViewModel.java
@@ -21,13 +21,13 @@ import lombok.Data;
 import static org.fossasia.openevent.core.auth.AuthUtil.INVALID;
 import static org.fossasia.openevent.core.auth.AuthUtil.VALID;
 
-public class FeedFragmentViewModel extends ViewModel {
+public class FacebookFeedFragmentViewModel extends ViewModel {
 
     private LiveData<FacebookPageId> facebookPageIdLiveData;
     private MutableLiveData<PostsResponse> feedLiveData;
     private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
-    public FeedFragmentViewModel() {
+    public FacebookFeedFragmentViewModel() {
         facebookPageIdLiveData = new MutableLiveData<>();
         feedLiveData = new MutableLiveData<>();
     }

--- a/android/app/src/main/java/org/fossasia/openevent/core/main/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/main/MainActivity.java
@@ -75,12 +75,11 @@ import org.fossasia.openevent.core.about.AboutFragment;
 import org.fossasia.openevent.core.auth.AuthUtil;
 import org.fossasia.openevent.core.auth.profile.UserProfileActivity;
 import org.fossasia.openevent.core.faqs.FAQFragment;
+import org.fossasia.openevent.core.feed.FeedFragment;
+import org.fossasia.openevent.core.feed.OpenCommentsDialogListener;
 import org.fossasia.openevent.core.feed.facebook.CommentsDialogFragment;
-import org.fossasia.openevent.core.feed.facebook.FeedAdapter;
-import org.fossasia.openevent.core.feed.facebook.FeedFragment;
 import org.fossasia.openevent.core.feed.facebook.api.CommentItem;
 import org.fossasia.openevent.core.feed.facebook.api.FacebookApi;
-import org.fossasia.openevent.core.feed.twitter.TwitterFeedFragment;
 import org.fossasia.openevent.core.location.LocationsFragment;
 import org.fossasia.openevent.core.notifications.NotificationsFragment;
 import org.fossasia.openevent.core.schedule.ScheduleFragment;
@@ -116,7 +115,7 @@ import io.realm.RealmList;
 import io.realm.RealmResults;
 import timber.log.Timber;
 
-public class MainActivity extends BaseActivity implements FeedAdapter.OpenCommentsDialogListener, OnImageZoomListener, AboutFragment.OnMapSelectedListener {
+public class MainActivity extends BaseActivity implements OpenCommentsDialogListener, OnImageZoomListener, AboutFragment.OnMapSelectedListener {
 
     private static final String STATE_FRAGMENT = "stateFragment";
     private static final String NAV_ITEM = "navItem";
@@ -534,9 +533,6 @@ public class MainActivity extends BaseActivity implements FeedAdapter.OpenCommen
                 break;
             case R.id.nav_feed:
                 replaceFragment(FeedFragment.getInstance(this, this), R.string.menu_feed);
-                break;
-            case R.id.nav_twitter_feed:
-                replaceFragment(TwitterFeedFragment.getInstance(this), R.string.menu_twitter);
                 break;
             case R.id.nav_schedule:
                 replaceFragment(new ScheduleFragment(), R.string.menu_schedule);

--- a/android/app/src/main/res/layout/fragment_feed_main.xml
+++ b/android/app/src/main/res/layout/fragment_feed_main.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        android:layout_alignParentStart="true"
+        android:layout_gravity="center_horizontal"
+        android:background="?attr/selectableItemBackground"
+        android:clipToPadding="false"
+        android:elevation="@dimen/tab_elevation"
+        app:tabBackground="?attr/selectableItemBackground"
+        app:tabGravity="center"
+        app:tabIndicatorHeight="@dimen/tab_indicator_height"
+        app:tabMaxWidth="@dimen/tab_max_width"
+        app:tabMinWidth="@dimen/tab_min_width"
+        app:tabMode="scrollable"
+        app:tabSelectedTextColor="@android:color/white"
+        tools:targetApi="lollipop" />
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/filter_bar"
+        android:background="@android:color/white" />
+
+</android.support.design.widget.AppBarLayout>

--- a/android/app/src/main/res/menu/drawer.xml
+++ b/android/app/src/main/res/menu/drawer.xml
@@ -28,53 +28,49 @@
             android:id="@+id/nav_feed"
             android:checked="true"
             android:icon="@drawable/ic_feed_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_feed" />
-        <item
-            android:id="@+id/nav_twitter_feed"
-            android:icon="@drawable/ic_feed_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/twitter_feed" />
+            android:title="@string/menu_feed"
+            app:showAsAction="always" />
+
         <item
             android:id="@+id/nav_tracks"
             android:checked="true"
             android:icon="@drawable/ic_event_white_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_tracks" />
+            android:title="@string/menu_tracks"
+            app:showAsAction="always" />
         <item
             android:id="@+id/nav_schedule"
             android:checked="true"
             android:icon="@drawable/ic_schedule_grey600_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_schedule" />
+            android:title="@string/menu_schedule"
+            app:showAsAction="always" />
 
 
         <item
             android:id="@+id/nav_speakers"
             android:icon="@drawable/ic_people_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_speakers" />
+            android:title="@string/menu_speakers"
+            app:showAsAction="always" />
         <item
             android:id="@+id/nav_sponsors"
             android:icon="@drawable/ic_sponsors_white_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_sponsor" />
+            android:title="@string/menu_sponsor"
+            app:showAsAction="always" />
         <item
             android:id="@+id/nav_map"
             android:icon="@drawable/ic_map_white_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_map" />
+            android:title="@string/menu_map"
+            app:showAsAction="always" />
         <item
             android:id="@+id/nav_locations"
             android:icon="@drawable/ic_location_on_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_locations" />
+            android:title="@string/menu_locations"
+            app:showAsAction="always" />
 
         <item
             android:id="@+id/nav_faqs"
             android:icon="@drawable/ic_question_answer_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_faqs" />
+            android:title="@string/menu_faqs"
+            app:showAsAction="always" />
 
     </group>
 
@@ -84,13 +80,13 @@
         <item
             android:id="@+id/nav_settings"
             android:icon="@drawable/ic_settings_black_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_settings" />
+            android:title="@string/menu_settings"
+            app:showAsAction="always" />
         <item
             android:id="@+id/nav_share"
             android:icon="@drawable/ic_share_white_24dp"
-            app:showAsAction="always"
-            android:title="@string/menu_share" />
+            android:title="@string/menu_share"
+            app:showAsAction="always" />
 
     </group>
 


### PR DESCRIPTION
Fixes #2326 
Changes: Made a new fragment with a view pager and tab layout which shows the two feed fragments.
Also refactored feedFragment to FacebookFeedFragment.

Screenshots of the change: 
![image](https://user-images.githubusercontent.com/22395998/36145720-37b44ba0-10d8-11e8-9be3-84f209767e0b.png)
