### PR TITLE
Fix #2330 Added cancel option in filter dialog box.

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/schedule/ScheduleFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/schedule/ScheduleFragment.java
@@ -234,9 +234,9 @@ public class ScheduleFragment extends BaseFragment implements OnBookmarkSelected
                         notifyUpdate(-1, selectedTracks);
                     }
                 })
-                .setNegativeButton("Cancel",((dialogInterface, i) -> {
+                .setNegativeButton("Cancel", (dialogInterface, i) -> {
                     isTrackSelected = Arrays.copyOf(saveSelectedTracks, saveSelectedTracks.length);
-                }));
+                });
 
         dialogSort.show();
     }

--- a/android/app/src/main/java/org/fossasia/openevent/core/schedule/ScheduleFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/schedule/ScheduleFragment.java
@@ -198,15 +198,13 @@ public class ScheduleFragment extends BaseFragment implements OnBookmarkSelected
 
     @OnClick (R.id.schedule_fab_filter)
     public void filterSchedule() {
+        boolean saveSelectedTracks[] = Arrays.copyOf(isTrackSelected, isTrackSelected.length);
         final AlertDialog.Builder dialogSort = new AlertDialog.Builder(context)
                 .setTitle(R.string.dialog_filter_title)
                 .setOnKeyListener((dialog, keyCode, event) -> {
                     if (keyCode == KeyEvent.KEYCODE_BACK &&
                             event.getAction() == KeyEvent.ACTION_UP &&
                             !event.isCanceled()) {
-                        Arrays.fill(isTrackSelected, false);
-                        selectedTracks.clear();
-                        notifyUpdate(-1, selectedTracks);
                         dialog.cancel();
                         return true;
                     }
@@ -233,8 +231,12 @@ public class ScheduleFragment extends BaseFragment implements OnBookmarkSelected
                         filterBar.setVisibility(View.VISIBLE);
                     } else {
                         filterBar.setVisibility(View.GONE);
+                        notifyUpdate(-1, selectedTracks);
                     }
-                });
+                })
+                .setNegativeButton("Cancel",((dialogInterface, i) -> {
+                    isTrackSelected = Arrays.copyOf(saveSelectedTracks, saveSelectedTracks.length);
+                }));
 
         dialogSort.show();
     }


### PR DESCRIPTION
Fixes #2330

Changes: Added the cancel option in the dialog box. Also removed the bug when the user presses back. When the user pressed back all the selected options were removed from the track but still the filter bar was showing the selected filtering options. Now on pressing back only the dialog box disappears.

Screenshot of the change:

![changes](https://user-images.githubusercontent.com/24502136/36494948-a3f71770-1759-11e8-9000-5724795389fa.png)


