### PR TITLE
fix: app crashes when facebook page id not found using page name

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/BaseFeedFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/BaseFeedFragment.java
@@ -1,39 +1,15 @@
 package org.fossasia.openevent.core.feed;
 
 import android.app.ProgressDialog;
-import android.content.DialogInterface;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
-import org.fossasia.openevent.R;
 import org.fossasia.openevent.common.ui.base.BaseFragment;
 
 import java.util.List;
 
 public abstract class BaseFeedFragment extends BaseFragment {
     protected ProgressDialog downloadProgressDialog;
-
-    protected void showProgressBar(boolean show) {
-        if (show)
-            downloadProgressDialog.show();
-        else
-            downloadProgressDialog.dismiss();
-    }
-
-    protected void setupProgressBar() {
-        downloadProgressDialog = new ProgressDialog(getContext());
-        downloadProgressDialog.setIndeterminate(true);
-        downloadProgressDialog.setProgressPercentFormat(null);
-        downloadProgressDialog.setProgressNumberFormat(null);
-        downloadProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        downloadProgressDialog.setCancelable(false);
-        String shownMessage = String.format(getString(R.string.downloading_format), getString(R.string.menu_feed));
-        downloadProgressDialog.setMessage(shownMessage);
-        downloadProgressDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getString(R.string.cancel), (dialogInterface, i) -> {
-            downloadProgressDialog.dismiss();
-            getActivity().onBackPressed();
-        });
-    }
 
     protected void handleVisibility() {
         if (!getFeedItems().isEmpty()) {

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/Resource.kt
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/Resource.kt
@@ -1,0 +1,22 @@
+package org.fossasia.openevent.core.feed
+
+data class Resource<T>(val status: Status, val data: T?, val message: String?) {
+
+    enum class Status {
+        SUCCESS,
+        ERROR
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun <T> success(data: T?): Resource<T> {
+            return Resource(Status.SUCCESS, data, null)
+        }
+
+        @JvmStatic
+        fun <T> error(msg: String, data: T?): Resource<T> {
+            return Resource(Status.ERROR, data, msg)
+        }
+    }
+}

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/api/PostsResponse.kt
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/api/PostsResponse.kt
@@ -1,3 +1,0 @@
-package org.fossasia.openevent.core.feed.facebook.api
-
-data class PostsResponse(val response: Int? = null, val feed: Feed? = null)

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/TwitterFeedFragmentViewModel.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/TwitterFeedFragmentViewModel.java
@@ -1,42 +1,35 @@
 package org.fossasia.openevent.core.feed.twitter;
 
 import android.arch.lifecycle.LiveData;
-import android.arch.lifecycle.MutableLiveData;
+import android.arch.lifecycle.LiveDataReactiveStreams;
 import android.arch.lifecycle.ViewModel;
 
-import org.fossasia.openevent.core.feed.twitter.api.PostsResponse;
+import org.fossasia.openevent.core.feed.Resource;
 import org.fossasia.openevent.core.feed.twitter.api.TwitterApi;
 import org.fossasia.openevent.core.feed.twitter.api.TwitterFeed;
+import org.reactivestreams.Publisher;
 
+import io.reactivex.BackpressureStrategy;
 import io.reactivex.android.schedulers.AndroidSchedulers;
-import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.schedulers.Schedulers;
-
-import static org.fossasia.openevent.core.auth.AuthUtil.INVALID;
-import static org.fossasia.openevent.core.auth.AuthUtil.VALID;
+import timber.log.Timber;
 
 public class TwitterFeedFragmentViewModel extends ViewModel {
-    private MutableLiveData<PostsResponse> feedLiveData;
-    private final CompositeDisposable compositeDisposable;
+    private LiveData<Resource<TwitterFeed>> feedLiveData;
 
-    public TwitterFeedFragmentViewModel() {
-        compositeDisposable = new CompositeDisposable();
-        feedLiveData = new MutableLiveData<>();
-    }
-
-    public LiveData<PostsResponse> getPosts(String query, int count, String source) {
-        compositeDisposable.add(TwitterApi.getLoklakAPI().getTwitterFeed(query, count, source)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(feed -> feedLiveData.setValue(new PostsResponse(VALID, feed))
-                    , throwable -> feedLiveData.setValue(new PostsResponse(INVALID, null))));
+    public LiveData<Resource<TwitterFeed>> getPosts(String query, int count, String source) {
+        if (feedLiveData == null) {
+            Publisher<Resource<TwitterFeed>> publisher = TwitterApi.getLoklakAPI().getTwitterFeed(query, count, source)
+                    .map(Resource::success)
+                    .onErrorReturn(throwable -> {
+                        Timber.e(throwable);
+                        return Resource.error(throwable.getMessage(), null);
+                    })
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .toFlowable(BackpressureStrategy.BUFFER);
+            feedLiveData = LiveDataReactiveStreams.fromPublisher(publisher);
+        }
         return feedLiveData;
     }
-
-    @Override
-    protected void onCleared() {
-        compositeDisposable.dispose();
-        super.onCleared();
-    }
-
 }

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/api/PostsResponse.kt
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/api/PostsResponse.kt
@@ -1,3 +1,0 @@
-package org.fossasia.openevent.core.feed.twitter.api
-
-data class PostsResponse(val response: Int? = null, val twitterFeed: TwitterFeed? = null)


### PR DESCRIPTION
Fixes #2362 
Changes: Changed facebook page id publisher to return invalid id when unable to find page id from page name.

Screenshot of the changes:
![20180404_214205](https://user-images.githubusercontent.com/19627767/38320213-960fd39a-3851-11e8-8f43-0d36ab35e251.gif)
