### PR TITLE
Fix #2395 - Let the user select his sharing medium everytime

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/main/MainActivity.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/main/MainActivity.java
@@ -493,7 +493,7 @@ public class MainActivity extends BaseActivity implements AboutFragment.OnMapSel
             shareIntent.setType("text/plain");
             shareIntent.putExtra(Intent.EXTRA_TEXT, String.format(getString(R.string.whatsapp_promo_msg_template),
                     String.format(getString(R.string.app_share_url),getPackageName())));
-            startActivity(shareIntent);
+            startActivity(Intent.createChooser(shareIntent, getString(R.string.share_via)));
         }
         catch (Exception e) {
             Snackbar.make(mainFrame, getString(R.string.error_msg_retry), Snackbar.LENGTH_SHORT).show();

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -340,6 +340,6 @@
     <string name="twitter_feed">Twitter Feed</string>
     <string name="featured_speakers_header">Featured Speakers</string>
     <string name="login_to_continue">Please login to continue</string>
-
+    <string name="share_via">Share via</string>
 
 </resources>


### PR DESCRIPTION
Fixes #2395 

Changes: Replace `startActivity()` with `startActivity(Intent.createChooser())` in shareApp()
