### PR TITLE
fix: login button and textview are not visible in all fragments now

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/notifications/NotificationsFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/notifications/NotificationsFragment.java
@@ -109,6 +109,11 @@ public class NotificationsFragment extends BaseFragment {
         }
     }
 
+    private void clearViews() {
+        noNotificationView.setVisibility(View.GONE);
+        loginBtn.setVisibility(View.GONE);
+    }
+
     public void onNotificationsDownloadDone(boolean status) {
         if (!status) {
             Timber.d("Notifications download failed");
@@ -145,6 +150,12 @@ public class NotificationsFragment extends BaseFragment {
     @Override
     protected int getLayoutResource() {
         return R.layout.list_notification;
+    }
+
+    @Override
+    public void onPause() {
+        clearViews();
+        super.onPause();
     }
 
     @Override


### PR DESCRIPTION
Fixes #2415 

Changes: Visibility of the views is made gone so that they do not persist after the notification fragment is no longer active

Screenshots for the change: N/A
