### PR TITLE
fix: add separate issue template

### DIFF
--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,29 @@
+### Bug Report    
+
+**Actual Behaviour**
+
+Please state here what is currently happening.
+
+**Expected Behaviour**
+
+State here what the feature should enable the user to do.
+
+**Steps to reproduce it**
+
+Add steps to reproduce bugs or add information on the place where the feature should be implemented. Add links to a sample deployment or code.
+
+**LogCat for the issue**
+
+Provide logs for the crash here
+
+**Screenshots of the issue**
+
+Where-ever possible attach a screenshot of the issue.
+
+**Android version and Phone Model**
+
+Add the Android version and the phone model on which the issue was encountered.
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/ISSUE_TEMPLATE/chore.md
+++ b/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,9 @@
+### Chore
+
+**Description**
+
+Please describe the task.  
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/ISSUE_TEMPLATE/feature.md
+++ b/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,9 @@
+### Feature Request
+
+**Feature Description**
+
+Please describe the feature you want to add to the project.
+
+**Would you like to work on the issue?**
+
+Please let us know if you can work on it or the issue should be assigned to someone else.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 The Open Event Android project consists of two components. The **App Generator** is a web application that is hosted on a server and generates an event Android app from a zip with JSON and binary files ([examples here](http://github.com/fossasia/open-event)) or through an API. The second component we are developing in the project is a generic **Android app** - the output of the app generator. The mobile app can be installed on any Android device for browsing information about the event. Updates can be made automatically through API endpoint connections from an online source (e.g. server), which needs to defined in the provided event zip with the JSON files. The Android app has a standard configuration file, that sets the details of the app (e.g. color scheme, logo of event, link to JSON app data).
 
+Have an issue? Create one using these:
+
+[![Bug](https://img.shields.io/badge/issues-bug-red.svg)](https://github.com/fossasia/open-event-android/issues/new?template=bug.md)
+[![Feature](https://img.shields.io/badge/issues-feature-green.svg)](https://github.com/fossasia/open-event-android/issues/new?template=feature.md)
+[![Chore](https://img.shields.io/badge/issues-chore-blue.svg)](https://github.com/fossasia/open-event-android/issues/new?template=chore.md)
+
 ## Communication
 
 Please join our mailing list to discuss questions regarding the project: https://groups.google.com/forum/#!forum/open-event


### PR DESCRIPTION
Fixes #2418 

Changes: Separate issue templates can now be used from the README.md

Screenshots for the change: N/A
