### PR TITLE
fix: text size fixed in FAQ and discount fragment

### DIFF
--- a/android/app/src/main/res/layout/fragment_faqs.xml
+++ b/android/app/src/main/res/layout/fragment_faqs.xml
@@ -20,7 +20,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:text="@string/no_faqs"/>
+        android:text="@string/no_faqs"
+        android:textAppearance="?android:textAppearanceMedium" />
 
     <Button
         android:id="@+id/btn_login"

--- a/android/app/src/main/res/layout/list_discount_codes.xml
+++ b/android/app/src/main/res/layout/list_discount_codes.xml
@@ -32,5 +32,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:text="No Disount Codes!" />
+        android:text="No Disount Codes!"
+        android:textAppearance="?android:textAppearanceMedium" />
 </RelativeLayout>


### PR DESCRIPTION
Fixes #2420 

Changes: text size fixed in FAQ and discount fragmen

Screenshots for the change: 
![screenshot_20180507-020931](https://user-images.githubusercontent.com/20878145/39677639-2140b5ca-519c-11e8-9ee6-0a2b6c395579.png)
![screenshot_20180507-020924](https://user-images.githubusercontent.com/20878145/39677640-2283800c-519c-11e8-9db4-f8dd6b2b858b.png)
