### PR TITLE
fix: description textviews have the same style

### DIFF
--- a/android/app/src/main/res/layout/content_session_detail.xml
+++ b/android/app/src/main/res/layout/content_session_detail.xml
@@ -262,14 +262,12 @@
 
             <TextView
                 android:id="@+id/tv_description"
+                style="@style/TextAppearance.AppCompat.Body1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/layout_margin_large"
                 android:autoLink="web"
-                android:gravity="start"
-                android:textColor="@android:color/black"
                 android:textIsSelectable="true"
-                android:textSize="@dimen/text_size_large"
                 tools:text="Open Event!" />
         </LinearLayout>
 


### PR DESCRIPTION
Fixes #2428 

Changes: description textviews have the same style

Screenshots for the change: 
![screenshot_20180508-012545](https://user-images.githubusercontent.com/20878145/39722088-206765ae-525f-11e8-9243-7e5f108825bd.png)
