### PR TITLE
fix: wrong app link shown on sharing speaker details

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/common/api/Urls.kt
+++ b/android/app/src/main/java/org/fossasia/openevent/common/api/Urls.kt
@@ -1,6 +1,7 @@
 package org.fossasia.openevent.common.api
 
 import android.webkit.URLUtil
+import org.fossasia.openevent.BuildConfig
 
 import org.fossasia.openevent.common.utils.Utils
 
@@ -52,7 +53,9 @@ object Urls {
 
     const val EMPTY_LINK = "http://xyz//"
 
-    private const val GOOGLE_PLAY_HOME = "https://play.google.com/store"
+    private const val APPLICATION_ID = BuildConfig.APPLICATION_ID
+
+    private const val GOOGLE_PLAY_HOME = "https://play.google.com/store/apps/details?id=$APPLICATION_ID"
 
     var baseUrl: String
         @JvmStatic


### PR DESCRIPTION
Fixes #2432 

Changes: correct app link shown on sharing speaker details

Screenshots for the change: 
![screenshot_20180509-010932](https://user-images.githubusercontent.com/20878145/39779220-1a029e96-5326-11e8-8c3c-a9cd55fed56c.png)
