### PR TITLE
fix : App crash on comment click fixed

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/CommentsListAdapter.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/CommentsListAdapter.java
@@ -11,6 +11,7 @@ import org.fossasia.openevent.R;
 import org.fossasia.openevent.common.ui.base.BaseRVAdapter;
 import org.fossasia.openevent.common.date.DateConverter;
 import org.fossasia.openevent.core.feed.facebook.api.CommentItem;
+import org.fossasia.openevent.core.feed.facebook.api.Commenter;
 import org.threeten.bp.format.DateTimeParseException;
 
 import java.util.List;
@@ -74,8 +75,10 @@ public class CommentsListAdapter extends BaseRVAdapter<CommentItem, CommentsList
             holder.comment.setVisibility(View.GONE);
         }
 
-        if (!TextUtils.isEmpty(commentItem.getFrom().getName())) {
-            holder.commenter.setText(commentItem.getFrom().getName());
+        Commenter from = commentItem.getFrom();
+        String fromName = from.getName();
+        if (from != null && !TextUtils.isEmpty(fromName)) {
+            holder.commenter.setText(fromName);
             holder.commenter.setVisibility(View.VISIBLE);
         } else {
             // status is empty, remove from view


### PR DESCRIPTION
Fixes #2452 

It seems that the JSON response from the graph API returns no user name of the person who commented and it only returns the "from" object if FOSSASIA comments. We can't access the names of the users who commented.

Link to the json [feed](https://graph.facebook.com/126893747338271/feed?fields=id%2Cfull_picture%2Cmessage%2Cstory%2Ccreated_time%2Clink%2Ccomments&access_token=1786614831603417|DWqP48Lm77hBqCQDWVsq4lFixuo)
