### PR TITLE
fix: text size corrected in feedback fragment

### DIFF
--- a/android/app/src/main/res/layout/list_feedbacks.xml
+++ b/android/app/src/main/res/layout/list_feedbacks.xml
@@ -32,5 +32,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:text="No Feedbacks!" />
+        android:text="No Feedbacks!"
+        android:textAppearance="?android:textAppearanceMedium" />
 </RelativeLayout>


### PR DESCRIPTION
Fixes #2455 

Changes:text size corrected in feedback fragment

Screenshots for the change: 
![screenshot_20180515-194600](https://user-images.githubusercontent.com/20878145/40062490-f74b3f40-5878-11e8-807e-0d527f1b1e6d.png)
