### PR TITLE
fix: improve UI of feed fragment

### DIFF
--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/facebook/FacebookFeedFragment.java
@@ -11,6 +11,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.fossasia.openevent.R;
@@ -42,8 +43,8 @@ public class FacebookFeedFragment extends BaseFeedFragment implements OpenCommen
     protected SwipeRefreshLayout swipeRefreshLayout;
     @BindView(R.id.feed_recycler_view)
     protected RecyclerView feedRecyclerView;
-    @BindView(R.id.txt_no_posts)
-    protected TextView noFeedView;
+    @BindView(R.id.ll_no_posts)
+    protected LinearLayout noFeedView;
 
     public static FacebookFeedFragment getInstance() {
         return new FacebookFeedFragment();

--- a/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/TwitterFeedFragment.java
+++ b/android/app/src/main/java/org/fossasia/openevent/core/feed/twitter/TwitterFeedFragment.java
@@ -12,6 +12,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.fossasia.openevent.R;
@@ -42,8 +43,8 @@ public class TwitterFeedFragment extends BaseFeedFragment implements OnImageZoom
     protected SwipeRefreshLayout swipeRefreshLayout;
     @BindView(R.id.twitter_feed_recycler_view)
     protected RecyclerView twitterFeedRecyclerView;
-    @BindView(R.id.twitter_txt_no_posts)
-    protected TextView noFeedView;
+    @BindView(R.id.ll_no_posts)
+    protected LinearLayout noFeedView;
 
     public static TwitterFeedFragment getInstance() {
         return new TwitterFeedFragment();

--- a/android/app/src/main/res/drawable/ic_no_posts_grey_24dp.xml
+++ b/android/app/src/main/res/drawable/ic_no_posts_grey_24dp.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:pathData="M0 0h24v24H0V0z" />
+    <path
+        android:fillColor="#727272"
+        android:pathData="M 15.5 8 C 16.3284271247 8 17 8.67157287525 17 9.5 C 17 10.3284271247 16.3284271247 11 15.5 11 C 14.6715728753 11 14 10.3284271247 14 9.5 C 14 8.67157287525 14.6715728753 8 15.5 8 Z" />
+    <path
+        android:fillColor="#727272"
+        android:pathData="M 8.5 8 C 9.32842712475 8 10 8.67157287525 10 9.5 C 10 10.3284271247 9.32842712475 11 8.5 11 C 7.67157287525 11 7 10.3284271247 7 9.5 C 7 8.67157287525 7.67157287525 8 8.5 8 Z" />
+    <path
+        android:fillColor="#727272"
+        android:pathData="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-6c-2.33 0-4.32 1.45-5.12 3.5h1.67c0.69-1.19 1.97-2 3.45-2s2.75 0.81 3.45 2h1.67c-0.8-2.05-2.79-3.5-5.12-3.5z" />
+</vector>

--- a/android/app/src/main/res/layout/list_feed.xml
+++ b/android/app/src/main/res/layout/list_feed.xml
@@ -7,14 +7,30 @@
     android:focusableInTouchMode="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <TextView
-        android:id="@+id/txt_no_posts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:text="@string/noFeed"
-        android:textAppearance="?android:textAppearanceMedium" />
+    <LinearLayout
+        android:id="@+id/ll_no_posts"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/img_no_posts"
+            android:layout_width="@dimen/item_image_view_extra_large"
+            android:layout_height="@dimen/item_image_view_extra_large"
+            android:layout_gravity="center"
+            android:layout_marginTop="@dimen/no_posts_margin"
+            app:srcCompat="@drawable/ic_no_posts_grey_24dp"
+            android:contentDescription="@string/sad_face"/>
+
+        <TextView
+            android:id="@+id/txt_no_posts"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/noFeed"
+            android:textAppearance="?android:textAppearanceMedium" />
+
+    </LinearLayout>
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/feed_swipe_refresh"

--- a/android/app/src/main/res/layout/list_twitter_feed.xml
+++ b/android/app/src/main/res/layout/list_twitter_feed.xml
@@ -7,14 +7,30 @@
     android:focusableInTouchMode="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    <TextView
-        android:id="@+id/twitter_txt_no_posts"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
-        android:text="@string/noFeed"
-        android:textAppearance="?android:textAppearanceMedium" />
+    <LinearLayout
+        android:id="@+id/ll_no_posts"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/img_no_posts"
+            android:layout_width="@dimen/item_image_view_extra_large"
+            android:layout_height="@dimen/item_image_view_extra_large"
+            android:layout_gravity="center"
+            android:layout_marginTop="@dimen/no_posts_margin"
+            app:srcCompat="@drawable/ic_no_posts_grey_24dp"
+            android:contentDescription="@string/sad_face"/>
+
+        <TextView
+            android:id="@+id/txt_no_posts"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/noFeed"
+            android:textAppearance="?android:textAppearanceMedium" />
+
+    </LinearLayout>
 
     <android.support.v4.widget.SwipeRefreshLayout
         android:id="@+id/twitter_feed_swipe_refresh"

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -67,6 +67,7 @@
     <dimen name="top_progressbar_margin">-10dp</dimen>
     <dimen name="bottom_progressbar_margin">-6dp</dimen>
     <dimen name="session_status_margin">60dp</dimen>
+    <dimen name="no_posts_margin">50dp</dimen>
 
     <!-- padding specifics -->
     <dimen name="padding_extra_small">2dp</dimen>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -228,6 +228,7 @@
     <string name="upcoming_sess">Upcoming session: </string>
     <string name="no_upcoming_Sess">No upcoming sessions</string>
     <string name="dash">&#160;-&#160;</string>
+    <string name="sad_face">Sad face</string>
 
     <!-- Sponsor types strings-->
     <string name="platinum">Platinum</string>


### PR DESCRIPTION
Fixes #2463 
Changes: An imageView is shown along with the text when there are no posts in the twitter or facebook feed

Screenshots for the change: 
![screenshot_20180516-161339](https://user-images.githubusercontent.com/20878145/40112655-5e60b010-5924-11e8-941d-1d3c32aadb45.png)
